### PR TITLE
Add Puppy Linux support

### DIFF
--- a/base/PUPPY/before.sh
+++ b/base/PUPPY/before.sh
@@ -1,0 +1,12 @@
+#
+# before.sh for DEBIAN and TYPE=workstation
+#
+
+# Add user's .ssh directory
+echo_step "  Make user's .ssh"
+mkdir -p "$(getent passwd "$MY_USERNAME" | cut -d: -f6)/.ssh"
+if [ "$?" -ne 0 ]; then
+	echo_warning "Failed to create, will attempt to continue"
+else
+	echo_success
+fi

--- a/base/PUPPY/before.sh
+++ b/base/PUPPY/before.sh
@@ -1,5 +1,5 @@
 #
-# before.sh for DEBIAN and TYPE=workstation
+# before.sh for PUPPY and ALL types
 #
 
 # Add user's .ssh directory


### PR DESCRIPTION
Hello, I'm trying to help with Puppy Linux support.

## Please Complete the Following

- [+] I used tabs to indent
- [+] I checked my code with [ShellCheck](https://www.shellcheck.net/)

## Notes

Puppy linux manager `pkg` have same name as FreeBSD's, but it's no compatible. So I add additional test to `pkg)` section inside `resync_installer`, i'm not sure if it's correct way.